### PR TITLE
Add urdftest to ros2 control

### DIFF
--- a/kuka_ros2_control_support/test/ros2_control_support.py
+++ b/kuka_ros2_control_support/test/ros2_control_support.py
@@ -224,6 +224,7 @@ class RobotDriverTest(unittest.TestCase):
         cls.node_name = "ros2_control_support_test"
         cls.node = Node(cls.node_name)
         cls.executor = rclpy.executors.SingleThreadedExecutor()
+        cls.executor.add_node(cls.node)
         cls.traj_state_topic = "/position_trajectory_controller/state"
         cls.joint_trajectory_topic = "/position_trajectory_controller/joint_trajectory"
         cls.trajectory_publisher = cls.node.create_publisher(


### PR DESCRIPTION
Added a test ensuring the TCP (tool0) is resolved correctly using TF. If a URDF is mal-formed (example mismatch of joint_names between base robot and ros2_control), the joint_state would be wrong and the Robot State Publisher would then not be capable of creating all TF.

This addition was tricky as tf listener in python is known to have some issues with spinning its thread see [1](https://github.com/ros2/geometry2/issues/438), [2](https://github.com/ros2/geometry2/issues/477)
